### PR TITLE
Yosemite fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,13 +13,31 @@ fi
 
 git submodule init
 git submodule update
+
+# NOTE: This gets most up-to-date packages. Desired behavior?
+# Submodules usually point to specific commits.
 git submodule foreach git pull origin master
+
+# If we're on OS X, first assert cmake is relatively recent,
+# and then delete the cmake directory for CUDA-dependent packages.
+# If this is not done on Yosemite,
+if [[ `uname` == "Darwin" ]]; then
+    # Check the dot version (currently only tested on Yosemite, 10.10)
+    osx_dotversion=$(sw_vers -productVersion | tr '.' "\n" | sed '2!d')
+    if [[ "$osx_dotversion" == "10" ]]; then
+        # This hurts me more than it hurts you
+        rm -rf ${currdir}/extra/cunn/cmake
+    fi
+fi
 
 mkdir -p build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release -DWITH_LUAJIT21=ON
 make && make install
 cd ..
+
+# Check for a CUDA install (using nvcc instead of nvidia-smi for cross-platform compatibility)
+path_to_nvcc=$(which nvcc)
 
 # check if we are on mac and fix RPATH for local install
 path_to_install_name_tool=$(which install_name_tool)
@@ -38,15 +56,12 @@ cd ${currdir}/pkg/paths && $PREFIX/bin/luarocks make rocks/paths-scm-1.rockspec
 cd ${currdir}/pkg/torch && $PREFIX/bin/luarocks make rocks/torch-scm-1.rockspec
 cd ${currdir}/pkg/dok && $PREFIX/bin/luarocks make rocks/dok-scm-1.rockspec
 cd ${currdir}/pkg/gnuplot && $PREFIX/bin/luarocks make rocks/gnuplot-scm-1.rockspec
-
 cd ${currdir}/exe/qtlua && $PREFIX/bin/luarocks make rocks/qtlua-scm-1.rockspec
 cd ${currdir}/exe/trepl && $PREFIX/bin/luarocks make
 cd ${currdir}/exe/env && $PREFIX/bin/luarocks make
-
 cd ${currdir}/extra/nn && $PREFIX/bin/luarocks make rocks/nn-scm-1.rockspec
 
-path_to_nvidiasmi=$(which nvidia-smi)
-if [ -x "$path_to_nvidiasmi" ]
+if [ -x "$path_to_nvcc" ]
 then
     cd ${currdir}/extra/cutorch && $PREFIX/bin/luarocks make rocks/cutorch-scm-1.rockspec
     cd ${currdir}/extra/cunn && $PREFIX/bin/luarocks make rocks/cunn-scm-1.rockspec
@@ -58,17 +73,11 @@ cd ${currdir}/pkg/sys && $PREFIX/bin/luarocks make sys-1.1-0.rockspec
 cd ${currdir}/pkg/xlua && $PREFIX/bin/luarocks make xlua-1.0-0.rockspec
 cd ${currdir}/pkg/image && $PREFIX/bin/luarocks make image-1.1.alpha-0.rockspec
 cd ${currdir}/pkg/optim && $PREFIX/bin/luarocks make optim-1.0.5-0.rockspec
-
 cd ${currdir}/extra/sdl2 && $PREFIX/bin/luarocks make rocks/sdl2-scm-1.rockspec
 cd ${currdir}/extra/threads && $PREFIX/bin/luarocks make rocks/threads-scm-1.rockspec
-
 cd ${currdir}/extra/graphicsmagick && $PREFIX/bin/luarocks make graphicsmagick-1.scm-0.rockspec
-
 cd ${currdir}/extra/argcheck && $PREFIX/bin/luarocks make rocks/argcheck-scm-1.rockspec
-
 cd ${currdir}/extra/audio && $PREFIX/bin/luarocks make audio-0.1-0.rockspec
-
 cd ${currdir}/extra/fftw3 && $PREFIX/bin/luarocks make rocks/fftw3-scm-1.rockspec
 cd ${currdir}/extra/signal && $PREFIX/bin/luarocks make rocks/signal-scm-1.rockspec
-
 cd ${currdir}/extra/nnx && $PREFIX/bin/luarocks make nnx-0.1-1.rockspec

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,11 @@ if [[ `uname` == "Darwin" ]]; then
         # This hurts me more than it hurts you
         rm -rf ${currdir}/extra/cunn/cmake
     fi
+
+    # Also, make sure that we build with Clang. CUDA's compiler nvcc
+    # does not play nice with any recent GCC version.
+    export CC=clang
+    export CXX=clang++
 fi
 
 mkdir -p build


### PR DESCRIPTION
Summary of fixes which should resolve #4 
* Changed the CUDA check to look for `nvcc`
* Explicitly remove cunn/cmake if we're on OS X 10.10 (ideally there'd be a PR to cunn which obviates this)
* Force the use of clang, because CUDA does not work with recent GCC versions.